### PR TITLE
Improve checking for NaNs and infs

### DIFF
--- a/pyBumpHunter/BumpHunter.py
+++ b/pyBumpHunter/BumpHunter.py
@@ -870,8 +870,7 @@ class BumpHunter():
         sig[H[0]<Hbkg] = 1-G(H[0][H[0]<Hbkg]+1,Hbkg[H[0]<Hbkg])
         sig = norm.ppf(1-sig)
         sig[sig<0] = 0 # If negative, set it to 0
-        sig[sig==np.inf] = 0 # Avoid errors
-        sig[sig==np.NaN] = 0
+        np.nan_to_num(sig, posinf=0, neginf=0, nan=0, copy=False) # Avoid errors
         sig[H[0]<Hbkg] = -sig[H[0]<Hbkg]  # Now we can make it signed
         
         # Plot the test histograms with the bump found by BumpHunter plus a little significance plot


### PR DESCRIPTION
Hi, thanks for this code!

A student of mine (@stsan9) found that the current checking for NaNs/infs can be improved. The current checking doesn't really work for NaNs because `np.nan == np.nan` returns  `False`.

See here: https://stackoverflow.com/questions/41342609/the-difference-between-comparison-to-np-nan-and-isnull